### PR TITLE
Added a safe assign initializer.

### DIFF
--- a/Tests/TSAOTests/Tests.swift
+++ b/Tests/TSAOTests/Tests.swift
@@ -16,6 +16,7 @@ let tupleMap = AssocMap<(Int, CGRect)>()
 
 let objectRetainMap = AssocMap<NSObject>()
 let objectAssignMap = AssocMap<NSObject>(assign: ())
+let objectSafeAssignMap = AssocMap<NSObject>(safeAssign: ())
 
 class TSAOTests: XCTestCase {
     var helper: NSObject!
@@ -99,5 +100,17 @@ class TSAOTests: XCTestCase {
             object = obj
         }
         XCTAssertNil(object)
+    }
+    
+    func testSafeAssignValue() {
+        weak var object: NSObject?
+        autoreleasepool {
+            let obj = NSObject()
+            objectSafeAssignMap[helper] = obj
+            object = obj
+            XCTAssertEqual(obj, objectSafeAssignMap[helper])
+        }
+        XCTAssertNil(object)
+        XCTAssertNil(objectSafeAssignMap[helper])
     }
 }


### PR DESCRIPTION
When using init(assign: ()), if value is deallocated, accessing the subscript results in a BAD_ACCESS.
Adding a safe assign initializer, where released value will just return nil instead.